### PR TITLE
Rename "gazebo" package to "gazebo_ros" for hydro

### DIFF
--- a/pr2_gazebo/launch/pr2_no_arms.launch
+++ b/pr2_gazebo/launch/pr2_no_arms.launch
@@ -4,7 +4,7 @@
   <param name="robot_description" command="$(find xacro)/xacro.py '$(find pr2_description)/robots/pr2_no_arms.urdf.xacro'" />
 
   <!-- push robot_description to factory and spawn robot in gazebo -->
-  <node name="spawn_pr2_model" pkg="gazebo" type="spawn_model" args="$(optenv ROBOT_INITIAL_POSE) -unpause -urdf -param robot_description -model pr2" respawn="false" output="screen" />
+  <node name="spawn_pr2_model" pkg="gazebo_ros" type="spawn_model" args="$(optenv ROBOT_INITIAL_POSE) -unpause -urdf -param robot_description -model pr2" respawn="false" output="screen" />
  
   <!-- Controller Manager -->
   <include file="$(find pr2_controller_manager)/controller_manager.launch" />

--- a/pr2_gazebo/launch/pr2_table_object.launch
+++ b/pr2_gazebo/launch/pr2_table_object.launch
@@ -26,10 +26,10 @@
   <!-- spawn table and tabletop object
   <param name="table_description" 
    command="$(find xacro)/xacro.py '$(find gazebo_worlds)/objects/table.urdf.xacro'" />
-  <node name="spawn_table" pkg="gazebo" type="spawn_model" args="-urdf -param table_description -model table_1" 
+  <node name="spawn_table" pkg="gazebo_ros" type="spawn_model" args="-urdf -param table_description -model table_1" 
    respawn="false" output="screen" />
 
-  <node name="spawn_object" pkg="gazebo" type="spawn_model" 
+  <node name="spawn_object" pkg="gazebo_ros" type="spawn_model" 
    args="-urdf -file $(find gazebo_worlds)/objects/coke_can.urdf -model object_1 -x 0.7 -z 0.55" 
    respawn="false" output="screen" />
   -->

--- a/pr2_gazebo/launch/pr2_table_simple_shapes.launch
+++ b/pr2_gazebo/launch/pr2_table_simple_shapes.launch
@@ -27,19 +27,19 @@
   <!-- spawn table and tabletop object
   <param name="table_description" 
    command="$(find xacro)/xacro.py '$(find gazebo_worlds)/objects/table.urdf.xacro'" />
-  <node name="spawn_table" pkg="gazebo" type="spawn_model" args="-urdf -param table_description -model table_1" 
+  <node name="spawn_table" pkg="gazebo_ros" type="spawn_model" args="-urdf -param table_description -model table_1" 
    respawn="false" output="screen" />
 
-  <node name="spawn_box1" pkg="gazebo" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/cube_red.urdf -wait table_1 -model cube_red_1 -x 0.7 -z 0.55" respawn="false" output="screen" />
-  <node name="spawn_box2" pkg="gazebo" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/cube_blue.urdf -wait cube_red_1 -model cube_blue_1 -x 0.7 -z 0.60" respawn="false" output="screen" />
-  <node name="spawn_box3" pkg="gazebo" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/cube_yellow.urdf -wait cube_blue_1 -model cube_yellow_1 -x 0.7 -z 0.65" respawn="false" output="screen" />
-  <node name="spawn_box4" pkg="gazebo" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/cube_green.urdf -wait cube_yellow_1 -model cube_green_1 -x 0.7 -z 0.70" respawn="false" output="screen" />
-  <node name="spawn_rec1" pkg="gazebo" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/rectangular_red.urdf -wait table_1 -model rectangular_red_1 -x 0.7 -y 0.05 -z 0.55" respawn="false" output="screen" />
-  <node name="spawn_rec2" pkg="gazebo" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/rectangular_yellow.urdf -wait rectangular_red_1 -model rectangular_yellow_1 -x 0.7 -y 0.05 -z 0.61" respawn="false" output="screen" />
-  <node name="spawn_cyl1" pkg="gazebo" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/cylinder_red.urdf -wait table_1 -model cylinder_red_1 -x 0.7 -y -0.05 -z 0.55" respawn="false" output="screen" />
-  <node name="spawn_cyl2" pkg="gazebo" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/cylinder_blue.urdf -wait cylinder_red_1 -model cylinder_blue_1 -x 0.7 -y -0.05 -z 0.65" respawn="false" output="screen" />
-  <node name="spawn_cyl3" pkg="gazebo" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/cylinder_yellow.urdf -wait cylinder_blue_1 -model cylinder_yellow_1 -x 0.7 -y -0.05 -z 0.75" respawn="false" output="screen" />
-  <node name="spawn_cyl4" pkg="gazebo" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/cylinder_green.urdf -wait cylinder_yellow_1 -model cylinder_green_1 -x 0.7 -y -0.05 -z 0.85" respawn="false" output="screen" />
+  <node name="spawn_box1" pkg="gazebo_ros" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/cube_red.urdf -wait table_1 -model cube_red_1 -x 0.7 -z 0.55" respawn="false" output="screen" />
+  <node name="spawn_box2" pkg="gazebo_ros" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/cube_blue.urdf -wait cube_red_1 -model cube_blue_1 -x 0.7 -z 0.60" respawn="false" output="screen" />
+  <node name="spawn_box3" pkg="gazebo_ros" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/cube_yellow.urdf -wait cube_blue_1 -model cube_yellow_1 -x 0.7 -z 0.65" respawn="false" output="screen" />
+  <node name="spawn_box4" pkg="gazebo_ros" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/cube_green.urdf -wait cube_yellow_1 -model cube_green_1 -x 0.7 -z 0.70" respawn="false" output="screen" />
+  <node name="spawn_rec1" pkg="gazebo_ros" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/rectangular_red.urdf -wait table_1 -model rectangular_red_1 -x 0.7 -y 0.05 -z 0.55" respawn="false" output="screen" />
+  <node name="spawn_rec2" pkg="gazebo_ros" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/rectangular_yellow.urdf -wait rectangular_red_1 -model rectangular_yellow_1 -x 0.7 -y 0.05 -z 0.61" respawn="false" output="screen" />
+  <node name="spawn_cyl1" pkg="gazebo_ros" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/cylinder_red.urdf -wait table_1 -model cylinder_red_1 -x 0.7 -y -0.05 -z 0.55" respawn="false" output="screen" />
+  <node name="spawn_cyl2" pkg="gazebo_ros" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/cylinder_blue.urdf -wait cylinder_red_1 -model cylinder_blue_1 -x 0.7 -y -0.05 -z 0.65" respawn="false" output="screen" />
+  <node name="spawn_cyl3" pkg="gazebo_ros" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/cylinder_yellow.urdf -wait cylinder_blue_1 -model cylinder_yellow_1 -x 0.7 -y -0.05 -z 0.75" respawn="false" output="screen" />
+  <node name="spawn_cyl4" pkg="gazebo_ros" type="spawn_model" args="-urdf -file $(find pr2_gazebo)/urdf/cylinder_green.urdf -wait cylinder_yellow_1 -model cylinder_green_1 -x 0.7 -y -0.05 -z 0.85" respawn="false" output="screen" />
   -->
 
   <!-- parameters that give you reasonable physics as well as good speed -->

--- a/pr2_gazebo/test/collisions/slide_world.launch
+++ b/pr2_gazebo/test/collisions/slide_world.launch
@@ -3,7 +3,7 @@
   <!-- start gazebo with an slide world -->
   <param name="/use_sim_time" value="true" />
 
-  <node name="gazebo" pkg="gazebo" type="gazebo" args="-u $(find pr2_gazebo)/test/collisions//slide.world" respawn="false" output="screen"/>
-  <node name="gazebo_gui" pkg="gazebo" type="gui" respawn="false" output="screen"/>
+  <node name="gazebo" pkg="gazebo_ros" type="gazebo" args="-u $(find pr2_gazebo)/test/collisions//slide.world" respawn="false" output="screen"/>
+  <node name="gazebo_gui" pkg="gazebo_ros" type="gui" respawn="false" output="screen"/>
 
 </launch>

--- a/pr2_gazebo/test/collisions/test_slide.launch
+++ b/pr2_gazebo/test/collisions/test_slide.launch
@@ -5,7 +5,7 @@
   <include file="$(find pr2_description)/robots/upload_pr2.launch" />
 
   <!-- push robot_description to factory and spawn robot in gazebo with a high starting position for the slide entry -->
-  <node name="spawn_pr2_model" pkg="gazebo" type="spawn_model" args="-unpause -urdf -param robot_description -y 6 -z 17 -P -1.3090 -Y 1.5708 -model pr2" respawn="false" output="screen" />
+  <node name="spawn_pr2_model" pkg="gazebo_ros" type="spawn_model" args="-unpause -urdf -param robot_description -y 6 -z 17 -P -1.3090 -Y 1.5708 -model pr2" respawn="false" output="screen" />
 
   <!-- default bringup script -->
   <include file="$(find pr2_gazebo)/launch/pr2_bringup.launch" />

--- a/pr2_gazebo/test/sensors/camera_world.launch
+++ b/pr2_gazebo/test/sensors/camera_world.launch
@@ -3,7 +3,7 @@
   <!-- start gazebo with an camera world -->
   <param name="/use_sim_time" value="true" />
 
-  <node name="gazebo" pkg="gazebo" type="gazebo" args="$(find pr2_gazebo)/test/sensors/camera.world" respawn="false" output="screen"/>
-  <node name="gazebo_gui" pkg="gazebo" type="gui" respawn="false" output="screen"/>
+  <node name="gazebo" pkg="gazebo_ros" type="gazebo" args="$(find pr2_gazebo)/test/sensors/camera.world" respawn="false" output="screen"/>
+  <node name="gazebo_gui" pkg="gazebo_ros" type="gui" respawn="false" output="screen"/>
 
 </launch>

--- a/pr2_gazebo/test/sensors/scan_world.launch
+++ b/pr2_gazebo/test/sensors/scan_world.launch
@@ -3,7 +3,7 @@
   <!-- start gazebo with an scan world -->
   <param name="/use_sim_time" value="true" />
 
-  <node name="gazebo" pkg="gazebo" type="gazebo" args="$(find pr2_gazebo)/test/sensors/scan.world" respawn="false" output="screen"/>
-  <node name="gazebo_gui" pkg="gazebo" type="gui" respawn="false" output="screen"/>
+  <node name="gazebo" pkg="gazebo_ros" type="gazebo" args="$(find pr2_gazebo)/test/sensors/scan.world" respawn="false" output="screen"/>
+  <node name="gazebo_gui" pkg="gazebo_ros" type="gui" respawn="false" output="screen"/>
 
 </launch>

--- a/pr2_gazebo/test/sensors/test_camera.launch
+++ b/pr2_gazebo/test/sensors/test_camera.launch
@@ -7,7 +7,7 @@
   <include file="$(find pr2_description)/robots/upload_pr2.launch" />
 
   <!-- push robot_description to factory and spawn robot in gazebo -->
-  <node name="spawn_pr2" pkg="gazebo" type="spawn_model" args="-urdf -param robot_description -x -3 -model pr2" respawn="false" output="screen" />
+  <node name="spawn_pr2" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -x -3 -model pr2" respawn="false" output="screen" />
  
   <!-- default bringup script -->
   <include file="$(find pr2_gazebo)/launch/pr2_bringup.launch" />

--- a/pr2_gazebo/test/spawn_test/pr2_spawn_with_offset.launch
+++ b/pr2_gazebo/test/spawn_test/pr2_spawn_with_offset.launch
@@ -10,7 +10,7 @@
   <include file="$(find pr2_description)/robots/upload_pr2.launch" />
 
   <!-- push robot_description to factory and spawn robot in gazebo -->
-  <node name="spawn_pr2_model" pkg="gazebo" type="spawn_model" args="-x 2 -y 2 -unpause -urdf -param robot_description -model pr2" respawn="false" output="screen" />
+  <node name="spawn_pr2_model" pkg="gazebo_ros" type="spawn_model" args="-x 2 -y 2 -unpause -urdf -param robot_description -model pr2" respawn="false" output="screen" />
 
 
   <!-- default bringup script -->

--- a/pr2_gazebo/test/spawn_test/test_pr2_spawn_with_offset.launch
+++ b/pr2_gazebo/test/spawn_test/test_pr2_spawn_with_offset.launch
@@ -3,8 +3,8 @@
   <!-- start gazebo with an empty plane -->
   <param name="/use_sim_time" value="true" />
 
-  <node name="gazebo" pkg="gazebo" type="gazebo" args="$(find pr2_gazebo)/test/spawn_test/origin_block.world" respawn="false" output="screen"/>
-  <node name="gazebo_gui" pkg="gazebo" type="gui" respawn="false" output="screen"/>
+  <node name="gazebo" pkg="gazebo_ros" type="gazebo" args="$(find pr2_gazebo)/test/spawn_test/origin_block.world" respawn="false" output="screen"/>
+  <node name="gazebo_gui" pkg="gazebo_ros" type="gui" respawn="false" output="screen"/>
 
   <!-- start pr2 robot -->
   <include file="$(find pr2_gazebo)/test/spawn_test/pr2_spawn_with_offset.launch"/>


### PR DESCRIPTION
Changed all instances of "gazebo" package to "gazebo_ros". The "gazebo" package was renamed "gazebo_ros" in hydro. This was mostly in launch files in "pr2_gazebo" package.
