### PR TITLE
update pr2_controller_configuration_gazebo gripper params

### DIFF
--- a/pr2_controller_configuration_gazebo/config/pr2_gripper_controllers.yaml
+++ b/pr2_controller_configuration_gazebo/config/pr2_gripper_controllers.yaml
@@ -2,7 +2,8 @@ r_gripper_controller:
   type: pr2_mechanism_controllers/Pr2GripperController
   joint: r_gripper_joint
   pid: &gripper_position_gains
-    p: 1000.0
+    p: 10000.0
+    d: 1000.0
 l_gripper_controller:
   type: pr2_mechanism_controllers/Pr2GripperController
   joint: l_gripper_joint


### PR DESCRIPTION
There was diff between https://github.com/PR2/pr2_robot/blob/hydro-devel/pr2_controller_configuration/pr2_gripper_controllers.yaml and https://github.com/PR2/pr2_simulator/blob/hydro-devel/pr2_controller_configuration_gazebo/config/pr2_gripper_controllers.yaml.

Because of P control and small p parameter, in Gazebo, the grasping motion was too slow unlike real robot.
Is there any historical reason about this?

I think this is related to http://answers.ros.org/question/191637/pr2-hydro-easiest-way-to-close-a-gripper/ .
