### PR TITLE
increase gripper_controller/gripper_action_node/stall_velocity_threshold

### DIFF
--- a/pr2_controller_configuration_gazebo/launch/pr2_default_controllers.launch
+++ b/pr2_controller_configuration_gazebo/launch/pr2_default_controllers.launch
@@ -31,7 +31,7 @@
     <node name="gripper_action_node"
           pkg="pr2_gripper_action" type="pr2_gripper_action">
       <!-- needed for stall detection in simulation with joint "jitter" -->
-      <param name="stall_velocity_threshold" value="0.02" type="double"/>
+      <param name="stall_velocity_threshold" value="0.33" type="double"/>
       <param name="stall_timeout" value="0.5" type="double"/>
     </node>
   </group>
@@ -39,7 +39,7 @@
     <node name="gripper_action_node"
           pkg="pr2_gripper_action" type="pr2_gripper_action">
       <!-- needed for stall detection in simulation with joint "jitter" -->
-      <param name="stall_velocity_threshold" value="0.02" type="double"/>
+      <param name="stall_velocity_threshold" value="0.33" type="double"/>
       <param name="stall_timeout" value="0.5" type="double"/>
     </node>
   </group>


### PR DESCRIPTION
Gripper action controller does not return result when grasing object.
While grasping object, gripper's velocity is about 0.2-0.3, which is much greater than `stall_velocity_threshold` parameter.
Increasing `stall_velocity_threshold` param fixes this problem.
- This plot shows gripper velocity while grasping.
  ![plot](https://cloud.githubusercontent.com/assets/1901008/11743688/cdf0a7ac-a04c-11e5-8552-b32b186c067d.png)

![screenshot from 2015-12-11 20 53 36](https://cloud.githubusercontent.com/assets/1901008/11743701/ebfbaf3a-a04c-11e5-9902-5304287d03f4.png)
