### PR TITLE
add missing GAZEBO_CXX_FLAGS

### DIFF
--- a/pr2_gazebo_plugins/CMakeLists.txt
+++ b/pr2_gazebo_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(pr2_gazebo_plugins)
 
 add_definitions(-fPIC)
@@ -106,6 +106,8 @@ include_directories(include
   ${OGRE_INCLUDE_DIRS}
   ${OGRE-Terrain_INCLUDE_DIRS}
 )
+
+add_compile_options(${GAZEBO_CXX_FLAGS})
 
 link_directories(
   ${GAZEBO_LIBRARY_DIRS}


### PR DESCRIPTION
This is required to compile the plugins with Gazebo 7.

add_compile_options requires cmake 2.8.12 which is around in ubuntu since
14.04.
