### PR TITLE
added CXXFLAGS for Gazebo 7.0+

### DIFF
--- a/pr2_gazebo_plugins/CMakeLists.txt
+++ b/pr2_gazebo_plugins/CMakeLists.txt
@@ -95,6 +95,8 @@ endif()
 
 # Depend on system install of Gazebo and SDFormat
 find_package(gazebo REQUIRED)
+# needed for Gazebo 7.0+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
 #find_package(PCL REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread)
 find_package(orocos_kdl)


### PR DESCRIPTION
Made this compile with Gazebo 7.0 which needs C++11 flags set.
