### PR TITLE
[pr2_gazebo/launch/pr2_empty_world.launch] add headless/debug arguments for gazebo

### DIFF
--- a/pr2_gazebo/launch/pr2_empty_world.launch
+++ b/pr2_gazebo/launch/pr2_empty_world.launch
@@ -2,6 +2,8 @@
 
   <!-- start up empty world -->
   <arg name="gui" default="true"/>
+  <arg name="headless" default="false" />
+  <arg name="debug" default="false" />
   <arg name="paused" default="true"/>
   <!-- TODO: throttled not implemented in gazebo_ros/empty_world.launch
   <arg name="throttled" default="false"/>
@@ -9,7 +11,10 @@
 
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="gui" value="$(arg gui)" />
+    <arg name="headless" value="$(arg headless)" />
     <arg name="paused" value="$(arg paused)" />
+    <arg name="debug" value="$(arg debug)" />
+    <arg name="use_sim_time" value="true" />
     <!-- TODO: throttled not implemented in gazebo_ros/empty_world.launch
     <arg name="throttled" value="$(arg throttled)" />
     -->


### PR DESCRIPTION
`gazebo_ros/launch/empty_world.launch` has an argument `headless` for executing on environment with no display.
This PR provides passing `headless` / `debug` argument to launch file which spawn `gazebo` node.

refered: https://github.com/fetchrobotics/fetch_gazebo/blob/gazebo2/fetch_gazebo/launch/playground.launch
