### PR TITLE
fix more cmake warnings

### DIFF
--- a/pr2_controller_configuration_gazebo/CMakeLists.txt
+++ b/pr2_controller_configuration_gazebo/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8.3)
 project(pr2_controller_configuration_gazebo)
 
 find_package(gazebo REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(SDF sdformat REQUIRED)
 
 find_package(catkin REQUIRED)
 

--- a/pr2_gazebo/CMakeLists.txt
+++ b/pr2_gazebo/CMakeLists.txt
@@ -1,11 +1,15 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(pr2_gazebo)
 
+find_package(gazebo REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(SDF sdformat REQUIRED)
+
 find_package(catkin REQUIRED)
 
 catkin_package(
   DEPENDS 
-    gazebo 
+    GAZEBO
     SDF
 )
 

--- a/pr2_gazebo_plugins/CMakeLists.txt
+++ b/pr2_gazebo_plugins/CMakeLists.txt
@@ -124,13 +124,11 @@ execute_process(COMMAND
 # build libraries
 add_library(gazebo_ros_controller_manager src/gazebo_ros_controller_manager.cpp)
 add_dependencies(gazebo_ros_controller_manager
-  ${PROJECT_NAME}_gencfg
   ${PROJECT_NAME}_generate_messages_cpp)
 target_link_libraries(gazebo_ros_controller_manager ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(gazebo_ros_power_monitor src/gazebo_ros_power_monitor.cpp)
 add_dependencies(gazebo_ros_power_monitor
-  ${PROJECT_NAME}_gencfg
   ${PROJECT_NAME}_generate_messages_cpp)
 target_link_libraries(gazebo_ros_power_monitor ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 

--- a/pr2_gazebo_plugins/CMakeLists.txt
+++ b/pr2_gazebo_plugins/CMakeLists.txt
@@ -3,6 +3,23 @@ project(pr2_gazebo_plugins)
 
 add_definitions(-fPIC)
 
+# system dependencies
+include (FindPkgConfig)
+if (PKG_CONFIG_FOUND)
+  pkg_check_modules(XML libxml-2.0)
+  pkg_check_modules(OGRE OGRE)
+  pkg_check_modules(OGRE-Terrain OGRE-Terrain)
+else()
+  message(FATAL_ERROR "pkg-config is required; please install it")
+endif()
+
+# Depend on system install of Gazebo and SDFormat
+find_package(gazebo REQUIRED)
+pkg_check_modules(SDF sdformat REQUIRED)
+#find_package(PCL REQUIRED)
+find_package(Boost REQUIRED COMPONENTS thread)
+find_package(orocos_kdl)
+
 # catkin dependencies
 find_package(catkin
   REQUIRED COMPONENTS 
@@ -74,29 +91,13 @@ catkin_package(
     tf 
     image_transport 
   DEPENDS 
-    gazebo 
+    GAZEBO
     SDF
     orocos_kdl
   LIBRARIES
     gazebo_ros_controller_manager
     gazebo_ros_power_monitor
 )
-
-# system dependencies
-include (FindPkgConfig)
-if (PKG_CONFIG_FOUND)
-  pkg_check_modules(XML libxml-2.0)
-  pkg_check_modules(OGRE OGRE)
-  pkg_check_modules(OGRE-Terrain OGRE-Terrain)
-else()
-  message(FATAL_ERROR "pkg-config is required; please install it")
-endif()
-
-# Depend on system install of Gazebo and SDFormat
-find_package(gazebo REQUIRED)
-#find_package(PCL REQUIRED)
-find_package(Boost REQUIRED COMPONENTS thread)
-find_package(orocos_kdl)
 
 include_directories(include
   ${Boost_INCLUDE_DIRS}


### PR DESCRIPTION
```
CMake Warning at /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:166 (message):
  catkin_package() DEPENDS on 'gazebo' but neither 'gazebo_INCLUDE_DIRS' nor
  'gazebo_LIBRARIES' is defined.
Call Stack (most recent call first):
  /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
  CMakeLists.txt:74 (catkin_package)


CMake Warning at /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:166 (message):
  catkin_package() DEPENDS on 'SDF' but neither 'SDF_INCLUDE_DIRS' nor
  'SDF_LIBRARIES' is defined.
Call Stack (most recent call first):
  /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
  CMakeLists.txt:74 (catkin_package)
```
```
The dependency target "pr2_gazebo_plugins_gencfg" of target
  "gazebo_ros_controller_manager" does not exist.
This warning is for project developers.  Use -Wno-dev to suppress it.

```