### PR TITLE
remove gazebo depends

### DIFF
--- a/pr2_gazebo/test/mechanism_controllers/test_arm.launch
+++ b/pr2_gazebo/test/mechanism_controllers/test_arm.launch
@@ -6,6 +6,7 @@
   <!-- startup pr2 -->
   <include file="$(find pr2_gazebo)/launch/pr2_empty_world.launch" >
     <arg name="gui" value="$(arg gui)" />
+    <arg name="world_name" value="$(find pr2_gazebo)/test/Media/worlds/empty.world" /> <!-- set empty.world for test, which does not require downloading models -->
   </include>
 
   <node name="tuckarm_server" pkg="pr2_tuck_arms_action" type="tuck_arms_main.py" />

--- a/pr2_gazebo/test/mechanism_controllers/test_base.launch
+++ b/pr2_gazebo/test/mechanism_controllers/test_base.launch
@@ -6,6 +6,7 @@
   <!-- Bring up the node we want to test. -->
   <include file="$(find pr2_gazebo)/launch/pr2_empty_world.launch">
     <arg name="gui" value="$(arg gui)" />
+    <arg name="world_name" value="$(find pr2_gazebo)/test/Media/worlds/empty.world" /> <!-- set empty.world for test, which does not require downloading models -->
   </include>
 
   <test test-name="test_pr2_mechanism_gazebo_test_base_vw1"      pkg="pr2_gazebo" type="test_base_vw_gt.py" />

--- a/pr2_gazebo_plugins/package.xml
+++ b/pr2_gazebo_plugins/package.xml
@@ -22,7 +22,6 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>diagnostic_msgs</build_depend>
   <build_depend>diagnostic_updater</build_depend>
-  <build_depend>gazebo</build_depend>
   <build_depend>gazebo_msgs</build_depend>
   <build_depend>gazebo_plugins</build_depend>
   <build_depend>geometry_msgs</build_depend>
@@ -47,7 +46,6 @@
 
  <!-- <run_depend>pcl_conversions</run_depend>
   <run_depend>pcl_ros</run_depend> -->
-  <run_depend>gazebo</run_depend>
   <run_depend>gazebo_ros</run_depend>
   <run_depend>gazebo_plugins</run_depend>
   <run_depend>gazebo_msgs</run_depend>


### PR DESCRIPTION
since gazebo_plugins already depend on gazebo via gazebo_dev and this solves build farm error on stretch http://build.ros.org/job/Mbin_dsv8_dSv8__pr2_gazebo_plugins__debian_stretch_arm64__binary/